### PR TITLE
Add requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ config = {
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
     ],
-    'version': '0.0.1',
+    'version': '0.0.2',
     'packages': ['h2tornado'],
     'scripts': [],
     'name': 'h2tornado',


### PR DESCRIPTION
If we upload the egg to our pypi and then try to install the package, it fails because it can't read the pip requirements file:
`
    ERROR: Command errored out with exit status 1:
     command: /home/vitaliy/mypypi/bin/python2 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-Y026JI/h2tornado/setup.py'"'"'; __file__='"'"'/tmp/pip-install-Y026JI/h2tornado/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: /tmp/pip-install-Y026JI/h2tornado/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-Y026JI/h2tornado/setup.py", line 7, in <module>
        with open('requirements.txt') as f:
    IOError: [Errno 2] No such file or directory: 'requirements.txt'
    ----------------------------------------
`

Similar to https://github.com/ContextLogic/tornado_dnslib/pull/5
